### PR TITLE
check the s3 package file exists

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -235,6 +235,16 @@ class Deb::S3::CLI < Thor
         end
       end
 
+      # check s3 for existing package, error out if package exists
+      log("check for existing package on s3")
+      manifests.each_value do |manifest|
+        begin
+          manifest.check_s3 { |f| sublog("Checking #{f}") }
+        rescue Deb::S3::Utils::AlreadyExistsError => e
+          error("Uploading failed because: #{e}")
+        end
+      end
+ 
       # upload the manifest
       log("Uploading packages and new manifests to S3")
       manifests.each_value do |manifest|
@@ -245,6 +255,7 @@ class Deb::S3::CLI < Thor
         end
         release.update_manifest(manifest)
       end
+
       release.write_to_s3 { |f| sublog("Transferring #{f}") }
 
       log("Update complete.")

--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -99,6 +99,17 @@ class Deb::S3::Manifest
     @packages.collect { |pkg| pkg.generate }.join("\n")
   end
 
+  def check_s3
+    unless self.skip_package_upload
+      # check any packages that may aleady exists
+      @packages_to_be_upload.each do |pkg|
+        yield pkg.url_filename if block_given?
+        s3_check(pkg.filename, pkg.url_filename, self.fail_if_exists)
+      end
+    end
+  end
+
+
   def write_to_s3
     manifest = self.generate
 

--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -64,6 +64,16 @@ module Deb::S3::Utils
     Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(path)].read
   end
 
+  def s3_check(path, filename=nil, fail_if_exists=false)
+    filename = File.basename(path) unless filename
+    obj = Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(filename)]
+
+    # check if the object already exists
+    if obj.exists?
+      raise AlreadyExistsError, "file #{obj.public_url} already exists" if fail_if_exists
+    end
+  end
+
   def s3_store(path, filename=nil, content_type='application/octet-stream; charset=binary', cache_control=nil, fail_if_exists=false)
     filename = File.basename(path) unless filename
     obj = Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(filename)]


### PR DESCRIPTION
it will check the package file on s3, if exists, exit immediately so the packages files not upload, preventing the corruption of index.

new output:
>> Retrieving existing manifests
>> Examining package file pinrepo-fix_1.0.60_amd64.deb
>> check for existing package on s3
   -- Checking pool/p/pi/pinrepo-fix_1.0.60_amd64.deb
!! Uploading failed because: file https://xxxxx/pinrepo-fix_1.0.60_amd64.deb already exists

Original output without this fix:
>> Retrieving existing manifests
>> Examining package file pinrepo-fix_1.0.60_amd64.deb
!! Uploading manifest failed because: file https://xxxxx/pinrepo-fix_1.0.60_amd64.deb already exists with different contents
>> Uploading packages and new manifests to S3
   -- Transferring dists/precise/main/binary-amd64/Packages
   -- Transferring dists/precise/main/binary-amd64/Packages.gz
   -- Transferring dists/precise/main/binary-i386/Packages
   -- Transferring dists/precise/main/binary-i386/Packages.gz
   -- Transferring pool/p/pi/pinrepo-fix_1.0.60_amd64.deb